### PR TITLE
Swap the summary and description fields

### DIFF
--- a/axiom-types.gemspec
+++ b/axiom-types.gemspec
@@ -7,8 +7,8 @@ Gem::Specification.new do |gem|
   gem.version     = Axiom::Types::VERSION.dup
   gem.authors     = ['Dan Kubb']
   gem.email       = 'dan.kubb@gmail.com'
-  gem.description = 'Abstract types for logic programming'
-  gem.summary     = 'Define types with optional constraints for use within axiom and other libraries.'
+  gem.summary     = 'Abstract types for logic programming'
+  gem.description = 'Define types with optional constraints for use within axiom and other libraries.'
   gem.homepage    = 'https://github.com/dkubb/axiom-types'
   gem.license     = 'MIT'
 


### PR DESCRIPTION
Currently the gem's summary is long, and the description is short. This ought to be the other way round.
