### PR TITLE
Upgrade to concurrent ruby from threadsafe

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,5 @@ platforms :rbx do
 end
 
 group :development, :test do
-  gem 'devtools', '= 0.0.2', git: 'https://github.com/mbj/devtools.git'
+  gem 'devtools', '~> 0.1.16'
 end

--- a/axiom-types.gemspec
+++ b/axiom-types.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency('descendants_tracker', '~> 0.0',  '>= 0.0.4')
   gem.add_runtime_dependency('ice_nine',            '~> 0.11', '>= 0.11.0')
-  gem.add_runtime_dependency('thread_safe',         '~> 0.3',  '>= 0.3.1')
+  gem.add_runtime_dependency('concurrent-ruby',     '~> 1.0',  '>= 1.0.4')
 
   gem.add_development_dependency('bundler')
 end

--- a/config/reek.yml
+++ b/config/reek.yml
@@ -18,6 +18,9 @@ ControlParameter:
   - Axiom::Types::Infinity#<=>
   - Axiom::Types::Object#self.infer_from_primitive_class
   - Axiom::Types::Type#self.infer
+ManualDispatch:
+  exclude:
+  - Axiom::Types::Options#assert_method_available
 DataClump:
   enabled: true
   exclude: []

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -37,6 +37,10 @@ LineLength:
   Exclude:
     - Gemfile
 
+# Ignore block length
+BlockLength:
+  Enabled: false
+
 # Disable documentation checking until a class needs to be documented once
 Documentation:
   Enabled: false
@@ -142,6 +146,10 @@ OpMethod:
 
 # Allow code to be aligned more nicely
 Style/SpaceBeforeFirstArg:
+  Enabled: false
+
+# Allow fail to be used rather than raise
+Style/SignalException:
   Enabled: false
 
 AmbiguousOperator:

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -100,7 +100,7 @@ SymbolArray:
 
 # Align if/else blocks with the variable assignment
 EndAlignment:
-  AlignWith: variable
+  EnforcedStyleAlignWith: variable
 
 # Do not always align parameters when it is easier to read
 AlignParameters:
@@ -141,7 +141,7 @@ OpMethod:
   Enabled: false
 
 # Allow code to be aligned more nicely
-SingleSpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
   Enabled: false
 
 AmbiguousOperator:

--- a/lib/axiom/types.rb
+++ b/lib/axiom/types.rb
@@ -7,7 +7,7 @@ require 'singleton'
 
 require 'descendants_tracker'
 require 'ice_nine'
-require 'thread_safe'
+require 'concurrent'
 
 module Axiom
 
@@ -24,7 +24,7 @@ module Axiom
     Contradiction = ->(_value) { true }.freeze
 
     # Cache the type inference lookup by object
-    @inference_cache = ThreadSafe::Cache.new do |cache, object|
+    @inference_cache = Concurrent::Hash.new do |cache, object|
       type = nil
       Type.descendants.detect do |descendant|
         type = descendant.infer(object)

--- a/lib/axiom/types/type.rb
+++ b/lib/axiom/types/type.rb
@@ -175,7 +175,7 @@ module Axiom
       #
       # @api private
       def self.add_constraint(constraint)
-        # rubocop:disable MethodCallParentheses
+        # rubocop:disable Style/MethodCallWithoutArgsParentheses
         current = constraint()
         @constraint = if current
           ->(object) { constraint.call(object) && current.call(object) }

--- a/lib/axiom/types/value_comparable.rb
+++ b/lib/axiom/types/value_comparable.rb
@@ -39,7 +39,7 @@ module Axiom
         return self if frozen?
         @range = IceNine.deep_freeze(minimum..maximum)
         use_value_within_range
-        super
+        super()
       end
 
     private
@@ -52,7 +52,7 @@ module Axiom
       #
       # @api private
       def use_value_within_range
-        constraint(range.method(:cover?))
+        constraint(range.public_method(:cover?))
       end
 
     end # module ValueComparable


### PR DESCRIPTION
[ThreadSafe](https://github.com/ruby-concurrency/thread_safe) is unmaintained and is not compatible with Ruby 2.4.0 because [Fixnum was unified into Integer](https://bugs.ruby-lang.org/issues/12005). This leads to loads of deprecation warnings on projects that use gems which depend on ThreadSafe.

This gem is a dependency of `virtus`, which is used quite widely. We've got a project which uses a gem which uses Virtus that we're running on 2.4.0 now, and I'm trying to cast a wide net and raise PR's that update this gem chain.

Switching to `Concurrent::Hash` from `ThreadSafe::Hash` is essentially a drop-in replacement, so that's what I've done here.

I've also had to update the `devtools` dependency to a released gem version (As a `bundle install` locally in development fails because the locked version isn't present on GH anymore).

As part of that upgrade I've updated the project local rubocop configuration to reflect the existing code, and fixed the reek configuration too.

I noticed Mutant failures while running `rake ci` -- I've done the suggested upgrades in 4d6ba63 but I'm not sure *why* they're good (I don't really understand these changes) so if you're feeling generous some explanation would be amazing :)

Thanks!